### PR TITLE
fix: missing property

### DIFF
--- a/src/Command/Shared/EventsTrait.php
+++ b/src/Command/Shared/EventsTrait.php
@@ -14,6 +14,8 @@ namespace Drupal\Console\Command\Shared;
  */
 trait EventsTrait
 {
+    private $events;
+    
     /**
      * @return mixed
      */


### PR DESCRIPTION
When calling `drupal generate:event:subscriber` : 

```
In EventsTrait.php line 59:
Undefined property: Drupal\Console\Command\Generate\EventSubscriberCommand::$events
```

The variable could either be in the trait or in the class using it. From what I've seen, it is only used in the EventSubscriberCommand class.